### PR TITLE
Don't update cboCompression's selected index to a proper default value

### DIFF
--- a/RandoTracker/Form1.cs
+++ b/RandoTracker/Form1.cs
@@ -99,8 +99,6 @@ namespace RandoTracker
                 // ignore error
             }
 
-            if (cboCompression.SelectedIndex < 0) cboCompression.SelectedIndex = 0;
-
             this.Left = 200;
             this.Top = 200;
 
@@ -176,6 +174,8 @@ namespace RandoTracker
             radVisState.Checked = false;
 
             loadGame();
+
+            if (cboCompression.SelectedIndex < 0) cboCompression.SelectedIndex = 0;
         }
 
         private void playerChange(object sender, EventArgs e)


### PR DESCRIPTION
until after the game is loaded as it requires the elements from the game
to exist currently.